### PR TITLE
後端導入 code quality 必要套件

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ output.txt
 package-lock.json
 Thumbs.db
 yarn-error.log
+.phplint-cache

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ _ide_helper.php
 .env.backup
 .idea
 .php_cs.cache
+.phplint-cache
 .phpunit.result.cache
 .phpstorm.meta.php
 .rnd
@@ -35,4 +36,3 @@ output.txt
 package-lock.json
 Thumbs.db
 yarn-error.log
-.phplint-cache

--- a/.phplint.yml
+++ b/.phplint.yml
@@ -1,0 +1,7 @@
+path: ./
+jobs: 10
+extensions:
+  - php
+exclude:
+  - vendor
+warning: false

--- a/.phplint.yml
+++ b/.phplint.yml
@@ -4,4 +4,3 @@ extensions:
   - php
 exclude:
   - vendor
-warning: false

--- a/composer.json
+++ b/composer.json
@@ -39,8 +39,10 @@
         "laravel/sail": "^1.14",
         "mockery/mockery": "^1.5",
         "nunomaduro/collision": "^6.2",
+        "overtrue/phplint": "^5.0",
         "phpunit/phpunit": "^9.5",
-        "roave/security-advisories": "dev-latest"
+        "roave/security-advisories": "dev-latest",
+        "squizlabs/php_codesniffer": "^3.7"
     },
     "autoload": {
         "psr-4": {
@@ -98,7 +100,10 @@
     "config": {
         "optimize-autoloader": true,
         "preferred-install": "dist",
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "treeware/plant": true
+        }
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<ruleset name="PHP_CodeSniffer">
+    <description>The coding standard for our project.</description>
+    <rule ref="PSR2"/>
+
+    <file>app</file>
+    <file>bootstrap</file>
+    <file>config</file>
+    <file>database</file>
+    <file>resources</file>
+    <file>routes</file>
+    <file>tests</file>
+
+    <exclude-pattern>bootstrap/cache/*</exclude-pattern>
+    <exclude-pattern>bootstrap/autoload.php</exclude-pattern>
+    <exclude-pattern>*/migrations/*</exclude-pattern>
+    <exclude-pattern>*/seeds/*</exclude-pattern>
+    <exclude-pattern>*.blade.php</exclude-pattern>
+    <exclude-pattern>*.js</exclude-pattern>
+
+    <!-- Show progression -->
+    <arg value="p"/>
+</ruleset>


### PR DESCRIPTION
#9 

## 使用方式

執行 `PHP_CodeSniffer`
```bash
./vendor/bin/phpcs --standard=phpcs.xml
```

> 更多用法可參考 https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage

執行 `phplint`
```bash
./vendor/bin/phplint
```

> 更多用法可參考 https://github.com/overtrue/phplint#usage